### PR TITLE
Updating for DSE 4.6.1 and Spark 1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" % "spark-streaming-kafka_2.10" % Spark % "provided",
   ("com.datastax.spark" %% "spark-cassandra-connector" % SparkCassandra withSources() withJavadoc()).
     exclude("com.esotericsoftware.minlog", "minlog").
-    exclude("commons-beanutils","commons-beanutils").
-    exclude("org.apache.spark","spark-core"),
+    exclude("commons-beanutils","commons-beanutils"),
   ("com.datastax.spark" %% "spark-cassandra-connector-java" % SparkCassandra withSources() withJavadoc()).
     exclude("org.apache.spark","spark-core"),
   "net.jpountz.lz4" % "lz4" % "1.2.0",

--- a/build.sbt
+++ b/build.sbt
@@ -2,33 +2,27 @@ import AssemblyKeys._
 
 name := "dse_spark_streaming_examples"
 
-version := "0.3.0"
+version := "0.2.0"
 
 scalaVersion := "2.10.4"
 
 val Spark = "1.1.0"
-
 val SparkCassandra = "1.1.0"
-
-libraryDependencies += ("org.apache.spark" % "spark-core_2.10" % Spark % "provided")
-
-libraryDependencies += ("org.apache.spark" % "spark-streaming_2.10" % Spark % "provided")
-
-libraryDependencies += ("org.apache.spark" % "spark-streaming-kafka_2.10" % Spark % "provided")
-
-libraryDependencies += ("com.datastax.spark" %% "spark-cassandra-connector" % SparkCassandra withSources() withJavadoc()).
-                        exclude("com.esotericsoftware.minlog", "minlog").
-                        exclude("commons-beanutils","commons-beanutils").
-                        exclude("org.apache.spark","spark-core")
-
-libraryDependencies += ("com.datastax.spark" %% "spark-cassandra-connector-java" % SparkCassandra withSources() withJavadoc()).
-                        exclude("org.apache.spark","spark-core")
-
-libraryDependencies += "net.jpountz.lz4" % "lz4" % "1.2.0"
 
 resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
 
-libraryDependencies ++= Seq(("com.typesafe.play" %% "play-json" % "2.2.1"))
+libraryDependencies ++= Seq(
+  "org.apache.spark" % "spark-core_2.10" % Spark % "provided",
+  "org.apache.spark" % "spark-streaming_2.10" % Spark % "provided",
+  "org.apache.spark" % "spark-streaming-kafka_2.10" % Spark % "provided",
+  ("com.datastax.spark" %% "spark-cassandra-connector" % SparkCassandra withSources() withJavadoc()).
+    exclude("com.esotericsoftware.minlog", "minlog").
+    exclude("commons-beanutils","commons-beanutils").
+    exclude("org.apache.spark","spark-core"),
+  ("com.datastax.spark" %% "spark-cassandra-connector-java" % SparkCassandra withSources() withJavadoc()).
+    exclude("org.apache.spark","spark-core"),
+  "net.jpountz.lz4" % "lz4" % "1.2.0",
+  "com.typesafe.play" %% "play-json" % "2.2.1")
 
 //We do this so that Spark Dependencies will not be bundled with our fat jar but will still be included on the classpath
 //When we do a sbt/run

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,28 @@
+import AssemblyKeys._
+
 name := "dse_spark_streaming_examples"
 
-version := "0.2.0"
+version := "0.3.0"
 
 scalaVersion := "2.10.4"
 
-libraryDependencies += "org.apache.spark" % "spark-core_2.10" % "0.9.1" % "provided"
+val Spark = "1.1.0"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming_2.10" % "0.9.1" % "provided"
+val SparkCassandra = "1.1.0"
 
-libraryDependencies += "org.apache.spark" % "spark-streaming-kafka_2.10" % "0.9.1" % "provided"
+libraryDependencies += ("org.apache.spark" % "spark-core_2.10" % Spark % "provided")
 
-libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector" % "1.0.0" withSources() withJavadoc()
+libraryDependencies += ("org.apache.spark" % "spark-streaming_2.10" % Spark % "provided")
 
-libraryDependencies += "com.datastax.spark" %% "spark-cassandra-connector-java" % "1.0.0" withSources() withJavadoc()
+libraryDependencies += ("org.apache.spark" % "spark-streaming-kafka_2.10" % Spark % "provided")
+
+libraryDependencies += ("com.datastax.spark" %% "spark-cassandra-connector" % SparkCassandra withSources() withJavadoc()).
+                        exclude("com.esotericsoftware.minlog", "minlog").
+                        exclude("commons-beanutils","commons-beanutils").
+                        exclude("org.apache.spark","spark-core")
+
+libraryDependencies += ("com.datastax.spark" %% "spark-cassandra-connector-java" % SparkCassandra withSources() withJavadoc()).
+                        exclude("org.apache.spark","spark-core")
 
 libraryDependencies += "net.jpountz.lz4" % "lz4" % "1.2.0"
 
@@ -25,3 +35,15 @@ libraryDependencies ++= Seq(("com.typesafe.play" %% "play-json" % "2.2.1"))
 run in Compile <<= Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run))
 
 assemblySettings
+
+mergeStrategy in assembly := {
+  case PathList("META-INF", "ECLIPSEF.RSA", xs @ _*)         => MergeStrategy.discard
+  case PathList("META-INF", "mailcap", xs @ _*)         => MergeStrategy.discard
+  case PathList("org", "apache","commons","collections", xs @ _*) => MergeStrategy.first
+  case PathList("org", "apache","commons","logging", xs @ _*) => MergeStrategy.first
+  case PathList(ps @ _*) if ps.last == "Driver.properties" => MergeStrategy.discard
+  case PathList(ps @ _*) if ps.last == "plugin.properties" => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (mergeStrategy in assembly).value
+    oldStrategy(x)
+}


### PR DESCRIPTION
I tried updating the sbt assembly plugin to 0.13 but that breaks everything.  This just updates the version of the Spark dependencies to correspond with the dependencies in DSE 4.6.1